### PR TITLE
Add UDP port to the chart for QUIC, and reorganize the service object

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,19 @@ Parameter | Description | Default | Required
 `config.email` | Email address used by Storj  | `nil` | yes
 `config.address` | (domain\|ip):port for external communication | `nil` | yes
 `config.storage` | Storage size allocated  | `1TB` | no
-`service.type` | Service type for the storagenode | `NodePort` | no
-`service.annotations` | Service annotations | `{}` | no
-`service.loadBalancerIP` | Secify a Load balancer IP if the provider allow you | null | no
-`service.port` | Service port for the storagenode | `28967` | no
-`service.nodePort` | Node port to expose for the storagenode | "" | no
+`service.storagenode.type` | Service type for the storagenode | `NodePort` | no
+`service.storagenode.annotations` | Service annotations | `{}` | no
+`service.storagenode.loadBalancerIP` | Secify a Load balancer IP if the provider allow you | null | no
+`service.storagenode.port` | Service port for the storagenode | `28967` | no
+`service.storagenode.nodePort` | Node port to expose for the storagenode | "" | no
+`service.stats.enabled` | Expose the node's Dashboard | `true` | no
+`service.stats.type` | Service type for the dashboard | `ClusterIP` | no
+`service.stats.port` | Service port for the dashboard | `14002` | no
+`service.quic.enabled` | Expose the storagenode's UDP port for quic | `true` | no
+`service.quic.type` | Service type for the storagenode's UDP port | `NodePort` | no
+`service.quic.loadBalancerIP` | Secify a Load balancer IP if the provider allow you | null | no
+`service.quic.port` | Service port for the storagenode's UDP port | `28967` | no
+`service.quic.nodePort` | Node port to expose for the storagenode's UDP port | "" | no
 `replicaCount` | Number of replica | `1` | no
 `podAnnotations` | Annotations for the pod | `{}` | no
 `podSecurityContext` | Custom security context | `{}` | no
@@ -71,9 +79,6 @@ Parameter | Description | Default | Required
 `storagenode.image.pullPolicy` | Container pull policy | `Always` | no
 `storagenode.securtyContext` | Custom security context for container | `{}` | no
 `storagenode.resources` | Resources request and limit YAML | `{}` | no
-`nodeStats.enabled` | Expose the node's Dashboard | `true` | no
-`nodeStats.service.type` | Service type for the dashboard | `ClusterIP` | no
-`nodeStats.service.port` | Service port for the dashboard | `14002` | no
 `identity.externalSecret.secretName` | Specify the secretName | `""` | yes
 `persistence.enabled` | Create a persistence volume | `true` | no
 `persistence.annotations` | Persistent volume claim annotation | `{}` | no

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ spec:
             - mysweetmachine   # -> Set your node hostname
 ```
 
+#### Sysctl Configuration for UDP
+
+If you have `service.quic` enabled (the default), you will need to update the `net.core.rmem_max` sysctl value, or the storj storagenode will complain in the logs. Doing this on your worker node(s) will pass the setting through to the storj pod. Note that this may impact other pods as well, since it is being done at the node level. Please see https://docs.storj.io/node/dependencies/quic-requirements/linux-configuration-for-udp/ for full details and instructions.
+
 ### Configuration
 
 Parameter | Description | Default | Required

--- a/charts/storj-storagenode/Chart.yaml
+++ b/charts/storj-storagenode/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.8
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/storj-storagenode/templates/service.yaml
+++ b/charts/storj-storagenode/templates/service.yaml
@@ -1,44 +1,39 @@
+{{- $fullName := include "storj-storagenode.fullname" . -}}
+{{- $labels := include "storj-storagenode.labels" . -}}
+{{- $selectorLabels := include "storj-storagenode.selectorLabels" . -}}
+{{- range $name, $service := .Values.service -}}
+  {{- if $service.enabled | default "true" -}}
+---  
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "storj-storagenode.fullname" . }}
+  name: {{ $fullName }}-{{ $name }}
   labels:
-    {{- include "storj-storagenode.labels" . | nindent 4 }}
+    {{- $labels | nindent 4 }}
   annotations:
-    {{- with .Values.service.annotations }}
-    {{- toYaml . | nindent 8 }}
+    {{- with $service.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- with .Values.service }}
+  {{- with $service }}
   type: {{ .type }}
   {{ if .loadBalancerIP }}loadBalancerIP: {{ .loadBalancerIP }}{{ end }}
   ports:
     - port: {{ .port }}
-      targetPort: storagenode
+      targetPort: {{ $name }}
+      {{- if .protocol }}
+      {{- if or ( eq .protocol "HTTP" ) ( eq .protocol "HTTPS" ) ( eq .protocol "TCP" ) }}
       protocol: TCP
-      name: storagenode
+      {{- else }}
+      protocol: {{ .protocol }}
+      {{- end }}
+      {{- else }}
+      protocol: TCP
+      {{- end }}
+      name: {{ $name }}
       {{ if .nodePort }}nodePort: {{ .nodePort }}{{ end }}
   {{- end }}
   selector:
-    {{- include "storj-storagenode.selectorLabels" . | nindent 4 }}
----
-{{- if .Values.nodeStats.enabled }}
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "storj-storagenode.fullname" . }}-stats
-  labels:
-    {{- include "storj-storagenode.labels" . | nindent 4 }}
-spec:
-  {{- with .Values.nodeStats.service }}
-  type: {{ .type }}
-  ports:
-    - port: {{ .port }}
-      targetPort: stats
-      protocol: TCP
-      name: stats
-      {{ if .nodePort }}nodePort: {{ .nodePort }}{{ end }}
+    {{- $selectorLabels | nindent 4 }}
   {{- end }}
-  selector:
-    {{- include "storj-storagenode.selectorLabels" . | nindent 4 }}
-{{- end }}
+{{ end }}

--- a/charts/storj-storagenode/templates/statefulset.yaml
+++ b/charts/storj-storagenode/templates/statefulset.yaml
@@ -39,10 +39,15 @@ spec:
             - name: storagenode
               containerPort: 28967
               protocol: TCP
-            {{- if .Values.nodeStats.enabled }}
+            {{- if .Values.service.stats.enabled }}
             - name: stats
               containerPort:  14002
               protocol: TCP
+            {{- end }}
+            {{- if .Values.service.quic.enabled }}
+            - name: quic
+              containerPort: 28967
+              protocol: UDP
             {{- end }}
           livenessProbe:
             tcpSocket:

--- a/charts/storj-storagenode/templates/tests/test-connection.yaml
+++ b/charts/storj-storagenode/templates/tests/test-connection.yaml
@@ -11,10 +11,10 @@ spec:
     - name: wget
       image: busybox
       command: ['nc']
-      args:  ['-zv', '{{ include "storj-storagenode.fullname" . }}', '{{ .Values.service.port }}']
+      args:  ['-zv', '{{ include "storj-storagenode.fullname" . }}', '{{ .Values.service.storagenode.port }}']
   restartPolicy: Never
 ---
-{{- if .Values.nodeStats.enabled }}
+{{- if .Values.service.stats.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -28,6 +28,24 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "storj-storagenode.fullname" . }}-stats:{{ .Values.nodeStats.service.port }}']
+      args:  ['{{ include "storj-storagenode.fullname" . }}-stats:{{ .Values.service.stats.port }}']
+  restartPolicy: Never
+{{- end }}
+---
+{{- if .Values.service.quic.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "storj-storagenode.fullname" . }}-quic-test-connection"
+  labels:
+{{ include "storj-storagenode.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['nc']
+      args:  ['-zvu', '{{ include "storj-storagenode.fullname" . }}', '{{ .Values.service.quic.port }}']
   restartPolicy: Never
 {{- end }}

--- a/charts/storj-storagenode/values.yaml
+++ b/charts/storj-storagenode/values.yaml
@@ -60,13 +60,27 @@ metrics:
   resources: {}
 
 service:
-  annotations: {}
-    # prometheus.io/scrape: "true"
-    # prometheus.io/port: "9651"
-  type: NodePort
-  loadBalancerIP:
-  port: 28967
-  nodePort: ""
+  storagenode:
+    annotations: {}
+      # prometheus.io/scrape: "true"
+      # prometheus.io/port: "9651"
+    type: NodePort
+    loadBalancerIP:
+    port: 28967
+    nodePort: ""
+  stats:
+    enabled: true
+    type: ClusterIP
+    port: 14002
+    nodePort: ""
+  quic:
+    enabled: true
+    type: NodePort
+    loadBalancerIP:
+    port: 28967
+    protocol: UDP
+    nodePort: ""
+
 
 # Ingress is used to expose the dashboard
 ingress:
@@ -97,13 +111,6 @@ persistence:
     resources:
       requests:
         storage: 2Ti
-
-nodeStats:
-  enabled: true
-  service:
-    type: ClusterIP
-    port: 14002
-    nodePort: ""
 
 config:
   # wallet: "0xdfca4035b9f16c40b558218d1bedc08590fe28d4"


### PR DESCRIPTION
Recent storj storage node releases have added a new UDP port to use the QUIC protocol in addition to the standard TCP port (https://forum.storj.io/t/experimenting-with-udp-based-protocols/11545). This pull request will add the new UDP service to the Chart, allowing it to be exposed on a Node.

As part of this addition, the service logic in `values.yaml` and `service.yaml` was updated to move all services under a common `service` dictionary and iterate over them. The `nodeStats` object no longer exists and was moved to `service.stats`.

This will create a breaking change for users who have a custom `values.yaml`, as they will need to update their file to match the changes to the service object. I'm not sure how you feel about breaking changes. Things could be reverted to the previous style and add a `quic.service` object in addition to `nodeStats.service`. Feel free to do so if you prefer.

I also bumped the version to `0.3.0`, given the breaking change. Again, feel free to modify that at your discretion.

I have been running this version on my node for several weeks. My node status page successfully shows that QUIC is working:
![image](https://user-images.githubusercontent.com/1591559/160295004-c295c51a-1f07-4d35-99ef-71ac8a0e3c49.png)
